### PR TITLE
add github action 🚀

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: Deploy to shopify
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+  #    - name: Build
+  #      run: |
+  #        npm install
+  #        npm run-script build
+      - name: Shopify
+        uses: pgrimaud/action-shopify@master
+        env:
+          SHOPIFY_PASSWORD: ${{ secrets.SHOPIFY_PASSWORD }}
+          SHOPIFY_STORE_URL: ${{ secrets.SHOPIFY_STORE_URL }}
+          SHOPIFY_THEME_ID: ${{ secrets.SHOPIFY_THEME_ID }}
+          THEME_PATH: ${{ secrets.THEME_PATH }}
+        with:
+          args: --ignored-file=config/settings_data.json


### PR DESCRIPTION
docs: https://github.com/pgrimaud/action-shopify

This is the github action I use to deploy to shopify.

The secrets have to be added to github => settings => secrets

You need to create a new private app with read and write access to the theme, if you dont have a specific subfolder for your theme use ./ as the theme path.

I use the commented out Build step to build React components that I output in the /assets folder